### PR TITLE
chore(DTSW-7781): bump duckietown_duckiebot compose pkg to v1.5.4

### DIFF
--- a/dependencies-compose.txt
+++ b/dependencies-compose.txt
@@ -1,7 +1,7 @@
 # LIST YOUR COMPOSE PACKAGES HERE
 data==v1.0.1
 duckietown==v1.1.9
-duckietown_duckiebot==v1.5.3
+duckietown_duckiebot==v1.5.4
 duckietown_duckiedrone==v2.2.1
 duckietown_ros==v0.0.1
 elfinder==v0.0.5


### PR DESCRIPTION
## Summary
- Bumps `duckietown_duckiebot` in `dependencies-compose.txt` from `v1.5.3` → `v1.5.4`.
- Picks up the fix for the `//mavros/imu/data` double-slash bug in the mission_control page when the dashboard is accessed via a non-mDNS URL.

## Jira
DTSW-7781

## Upstream
- duckietown/compose-pkg-duckietown-duckiebot — fix/DTSW-7781-mission-control-empty-vehicle-name (tag v1.5.4 pushed)

## Test plan
- [ ] Build dashboard image with the bumped dep.
- [ ] Verify mission_control topics resolve to `/mavros/...` (single slash) via `localhost:8080` on virtual drone.