### PR TITLE
DTSW-7878 Update Duckiedrone dashboard calibration dependency

### DIFF
--- a/dependencies-compose.txt
+++ b/dependencies-compose.txt
@@ -2,7 +2,7 @@
 data==v1.0.1
 duckietown==v1.1.9
 duckietown_duckiebot==v1.5.1
-duckietown_duckiedrone==v2.1.0
+duckietown_duckiedrone==v2.1.1
 duckietown_ros==v0.0.1
 elfinder==v0.0.5
 portainer==v1.0.2


### PR DESCRIPTION
## Summary
- Bump the Duckiedrone compose package dependency to `duckietown_duckiedrone==v2.1.1`.
- Keeps the dashboard install path aligned with the PX4 IMU calibration UI changes in the Duckiedrone compose package.

## Related
- Duckiedrone compose package PR: https://github.com/duckietown/compose-pkg-duckietown-duckiedrone/pull/9
- ROS2 interface PR: https://github.com/duckietown/dt-ros2-interface/pull/17
- DD24 opmanual PR: https://github.com/duckietown/book-opmanual-dd24/pull/25