### PR TITLE
DTSW-7986-Update-Dashboard

### DIFF
--- a/launchers/default.sh
+++ b/launchers/default.sh
@@ -61,6 +61,12 @@ compose configuration/set --package core \
     theme=core:modern \
     favicon=duckietown
 
+# the shared duckietown_duckiebot pages resolve the robot name and expand
+# `~` topics using these settings, including on forwarded localhost sessions
+compose configuration/set --package duckietown_duckiebot \
+    duckiebot_name=${HOSTNAME} \
+    duckiebot_hostname=${HOSTNAME}.local
+
 # configure theme
 compose theme/set \
     colors/primary/background=#2c5686 \


### PR DESCRIPTION
This pull request makes a configuration improvement to the `launchers/default.sh` script. It ensures that the `duckiebot_name` and `duckiebot_hostname` settings are automatically set based on the current host, which helps shared Duckietown Duckiebot pages resolve robot names and expand topics correctly, even on forwarded localhost sessions.

Configuration improvements for Duckiebot pages:

* Added commands to set `duckiebot_name` and `duckiebot_hostname` in the `duckietown_duckiebot` package using the current `${HOSTNAME}`, improving topic resolution and hostname expansion for shared Duckiebot pages.